### PR TITLE
Fix Switch controller initialization race condition

### DIFF
--- a/ios/ios_pad/source/controllers/switch_controller.c
+++ b/ios/ios_pad/source/controllers/switch_controller.c
@@ -479,7 +479,7 @@ static void handle_command_response(Controller* controller, SwitchCommandRespons
         } else {
             // Don't need to wait for calibration, controller is ready now
             controller->isReady = 1;
-        }  
+        }
     } else if (resp->command == SWITCH_COMMAND_SPI_FLASH_READ) {
         uint32_t address = bswap32(resp->spi_flash_read.address);
 

--- a/ios/ios_pad/source/controllers/switch_controller.c
+++ b/ios/ios_pad/source/controllers/switch_controller.c
@@ -465,11 +465,11 @@ static void handle_command_response(Controller* controller, SwitchCommandRespons
 
         // set the leds now that we know the device type
         setPlayerLeds(controller);
-
+    } else if (resp->command == SWITCH_COMMAND_SET_PLAYER_LEDS) {
         // enable rumble
         setVibration(controller, 1);
-
-                                                         /* Calibration causes issues for third-party controllers */
+    } else if (resp->command == SWITCH_COMMAND_ENABLE_VIBRATION) {
+        /* Calibration causes issues for some third-party controllers */
         if ((sdata->device == SWITCH_DEVICE_JOYCON_LEFT || /*sdata->device == SWITCH_DEVICE_TP_JOYCON_LEFT ||*/
              sdata->device == SWITCH_DEVICE_JOYCON_RIGHT || /*sdata->device == SWITCH_DEVICE_TP_JOYCON_RIGHT ||*/
              sdata->device == SWITCH_DEVICE_PRO || /*sdata->device == SWITCH_DEVICE_TP_PRO ||*/
@@ -479,7 +479,7 @@ static void handle_command_response(Controller* controller, SwitchCommandRespons
         } else {
             // Don't need to wait for calibration, controller is ready now
             controller->isReady = 1;
-        }
+        }  
     } else if (resp->command == SWITCH_COMMAND_SPI_FLASH_READ) {
         uint32_t address = bswap32(resp->spi_flash_read.address);
 

--- a/ios/ios_pad/source/controllers/switch_controller.c
+++ b/ios/ios_pad/source/controllers/switch_controller.c
@@ -466,6 +466,10 @@ static void handle_command_response(Controller* controller, SwitchCommandRespons
         // set the leds now that we know the device type
         setPlayerLeds(controller);
     } else if (resp->command == SWITCH_COMMAND_SET_PLAYER_LEDS) {
+        // Early return for controllers that are already initialized
+        if(controller->isReady) {
+            return;
+        }
         // enable rumble
         setVibration(controller, 1);
     } else if (resp->command == SWITCH_COMMAND_ENABLE_VIBRATION) {


### PR DESCRIPTION
Switch controllers require ACK responses between initialization commands to process them correctly. The previous implementation sent setPlayerLeds(), setVibration(), and readSpiFlash() commands in rapid succession without waiting for acknowledgments, causing race conditions.

Changes:
- Restructured command sequence to wait for each ACK before sending next command
- setPlayerLeds() now triggers setVibration() on ACK
- setVibration() now triggers calibration reads on ACK
- Ensures proper controller state before attempting calibration data reads